### PR TITLE
Switch to BLAKE2s with blakejs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 `anonymous-user-id` is a JavaScript library that allows you to anonymously identify unique users on your website without requiring them to store (and consent to) a tracking cookie. Instead, we generate a unique ID for each user based on information that can be pulled out of a regular HTTP request, mainly the source IP address and `User-Agent` header.
 
-The method we use to do this is heavily inspired by [Plausible Analytics](https://plausible.io/data-policy#how-we-count-unique-users-without-cookies), with [BLAKE3](https://github.com/BLAKE3-team/BLAKE3) as the hash function.
+The method we use to do this is heavily inspired by [Plausible Analytics](https://plausible.io/data-policy#how-we-count-unique-users-without-cookies), with [BLAKE2s](https://tools.ietf.org/html/rfc7693) as the hash function.
 
 ## Supported Algorithms
 

--- a/package.json
+++ b/package.json
@@ -38,11 +38,11 @@
   "size-limit": [
     {
       "path": "dist/anonymous-user-id.cjs.production.min.js",
-      "limit": "10 KB"
+      "limit": "30 KB"
     },
     {
       "path": "dist/anonymous-user-id.esm.js",
-      "limit": "10 KB"
+      "limit": "30 KB"
     }
   ],
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "typescript": "^4.2.4"
   },
   "dependencies": {
-    "blake3": "^2.1.4",
+    "blakejs": "^1.1.0",
     "date-fns": "^2.21.1"
   },
   "publishConfig": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import * as blake3 from 'blake3';
+import { blake2sHex } from 'blakejs';
 import { formatISO } from 'date-fns';
 
 interface RequestDetails {
@@ -7,8 +7,7 @@ interface RequestDetails {
   userAgent?: string;
 }
 
-const hash = (input: blake3.HashInput): string =>
-  blake3.hash(input).toString('hex');
+const hash = (input: string): string => blake2sHex(input);
 
 /**
  * Get a standard anonymous user ID (hash(salt + domain + ip + user_agent)),

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -12,7 +12,7 @@ test('getAnonymousUserId', () => {
       ip: '1.1.1.1',
       userAgent: 'test/1.0',
     })
-  ).toEqual('596837e254826733d2078f28beb170c7487c35685dfdbd7d60fe73623a257ef7');
+  ).toEqual('7a7a88b65404da1983bff9f57c27f4449f7f0d3a68f526f65fb57ab958e09bfc');
 });
 
 test('getAnonymousUserIdWithSecret', () => {
@@ -22,5 +22,5 @@ test('getAnonymousUserIdWithSecret', () => {
       ip: '1.1.1.1',
       userAgent: 'test/1.0',
     })
-  ).toEqual('aa322ee77d60c096af65b37d7f73a1a2df6252dcf2d4a5a6464c93ca40bece78');
+  ).toEqual('6f3dd1b774fd27004d890d12150ffa5a793d2d7d68d631478de4e307897eee17');
 });

--- a/types/dependencies.d.ts
+++ b/types/dependencies.d.ts
@@ -1,0 +1,3 @@
+declare module 'blakejs' {
+  declare function blake2sHex(input: string): string;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2135,10 +2135,10 @@ bl@^4.1.0:
     inherits "^2.0.4"
     readable-stream "^3.4.0"
 
-blake3@^2.1.4:
-  version "2.1.4"
-  resolved "https://registry.yarnpkg.com/blake3/-/blake3-2.1.4.tgz#78117bc9e80941097fdf7d03e897a9ee595ecd62"
-  integrity sha512-70hmx0lPd6zmtNwxPT4/1P0pqaEUlTJ0noUBvCXPLfMpN0o8PPaK3q7ZlpRIyhrqcXxeMAJSowNm/L9oi/x1XA==
+blakejs@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/blakejs/-/blakejs-1.1.0.tgz#69df92ef953aa88ca51a32df6ab1c54a155fc7a5"
+  integrity sha1-ad+S75U6qIylGjLfarHFShVfx6U=
 
 bluebird@^3.5.5:
   version "3.7.2"


### PR DESCRIPTION
This is unfortunate as BLAKE2s is an older and slower hash function, but BLAKE3 doesn't have a pure-JavaScript implementation (`blake3` uses either native bindings or wasm), which we need to support usecases such as serverless functions bundled with webpack.

That being said I wouldn't consider this a breaking change, as while the new IDs will obviously be incompatible with the old ones, they're supposed to be short-lived anyway.